### PR TITLE
Adding BH as explicit requirement

### DIFF
--- a/r-packages.R
+++ b/r-packages.R
@@ -1,6 +1,7 @@
 options("repos"="http://cran.rstudio.com") # set the cran mirror
 
-packages <- c("devtools",
+packages <- c("BH",
+              "devtools",
               "ggplot2",
               "tidyr",
               "dplyr",


### PR DESCRIPTION
In my fork, I've found I have to explicitly install the boost headers right now, or else the install script fails on the entire Hadleyverse. I have no idea why it doesn't get caught as a dependency; maybe it's erroneously in 'suggests,' or maybe Wickham put a bad version number into one of his packages.
